### PR TITLE
lang cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# IDEA
 .idea
+
+# Sublime
 *.sublime-project
 *.sublime-workspace
+
+# Eclipse
+.project

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,7 +3,10 @@
 		"authors": [
 			"Jinbobo <paullee05149745@gmail.com>",
 			"Peter Atashian",
-			"Telshin <timmrysk@gmail.com>"
+			"Telshin <timmrysk@gmail.com>",
+			"Eli Foster <elifosterwy@gmail.com>",
+			"Cblair91",
+			"Eric Schneider (Xbony2)"
 		]
 	},
 	"tilelist": "Item List",
@@ -29,7 +32,7 @@
 	"tilesheet-tile-list-limit": "Entries per page",
 	"tilesheet-create-legend": "Create new tilesheet",
 	"tilesheet-create-mod": "Mod name",
-	"tilesheet-create-mod-hint": "The abbreviation of the mod as defined in [[Module:Mods/list]].",
+	"tilesheet-create-mod-hint": "The abbreviation of the mod.",
 	"tilesheet-create-sizes": "Tilesheet sizes",
 	"tilesheet-create-sizes-hint": "Comma separated integers of tilesheet sizes, tilesheets should be uploaded to <code>Tilesheet $mod $size.png</code>.",
 	"tilesheet-create-input": "Import data",
@@ -42,7 +45,7 @@
 	"tilesheet-sheet-manager-filter-submit": "Go",
 	"tilesheet-sheet-manager-legend": "Update Sheet",
 	"tilesheet-sheet-manager-mod": "Mod Abbreviation",
-	"tilesheet-sheet-manager-mod-hint": "The abbreviation of the mod as defined in [[Module:Mods/list]].",
+	"tilesheet-sheet-manager-mod-hint": "The abbreviation of the mod.",
 	"tilesheet-sheet-manager-sizes": "Tilesheet Sizes",
 	"tilesheet-sheet-manager-sizes-hint": "Comma separated integers of tilesheet sizes, tilesheets should be uploaded to <code>Tilesheet $mod $size.png</code>.",
 	"tilesheet-sheet-manager-delete": "<span style=\"color:red; font-weight:bold;\">Delete Sheet</span>",
@@ -55,7 +58,7 @@
 	"tilesheet-tile-manager-id": "Entry ID",
 	"tilesheet-tile-manager-item": "Item Name",
 	"tilesheet-tile-manager-mod": "Mod Abbreviation",
-	"tilesheet-tile-manager-mod-hint": "The abbreviation of the mod as defined in [[Module:Mods/list]].",
+	"tilesheet-tile-manager-mod-hint": "The abbreviation of the mod.",
 	"tilesheet-tile-manager-x": "X Position",
 	"tilesheet-tile-manager-y": "Y Position",
 	"tilesheet-tile-manager-delete": "<span style=\"color:red; font-weight:bold;\">Delete Entry</span>",


### PR DESCRIPTION
(Usually just people who modify/create the lang file are listed as authors)

Also, I removed references to [[Module:Mods/list]]. It would be good to include it as a modified system message, but not as the default one; [[Module:Mods/list]] is FTB Wiki-specific, and may not be applicable if, say, the Russian Minecraft decided to use this extension (or more likely, when FTB makes an independent game).