### PR TITLE
Can't always rely on MW's API parser to provide an integer.

### DIFF
--- a/api/TilesheetsQueryTilesApi.php
+++ b/api/TilesheetsQueryTilesApi.php
@@ -54,8 +54,8 @@ class TilesheetsQueryTilesApi extends ApiQueryBase {
             'ext_tilesheet_items',
             '*',
             array(
-                "mod_name = {$dbr->addQuotes($mod)} or {$dbr->addQuotes($mod)} = ''",
-                "entry_id >= $from"
+                "mod_name = {$dbr->addQuotes($mod)} OR {$dbr->addQuotes($mod)} = ''",
+                "entry_id >= ".intval($from)
             ),
             __METHOD__,
             array('LIMIT' => $limit + 1,)


### PR DESCRIPTION
MW's API should always provider an integer to the $from variable, but if they ever encounter a bug in that functionality it would immediately create a SQL injection vector in the code.  For sanity $from is wrapped in intval().